### PR TITLE
Fix situation when delete action caused null reference in cleanup method of TransactionBase class

### DIFF
--- a/transactional_clock/core/storage.py
+++ b/transactional_clock/core/storage.py
@@ -20,7 +20,7 @@ class TransactionBase:
 
     def __cleanup(self):
         key = '_id'
-        if key in self._data.keys():
+        if self._data is not None and key in self._data.keys():
             del self._data[key]
 
     @property


### PR DESCRIPTION
Check please if you can reproduce this exception or contact me. 
I will create some minimal request that causes this exception to demonstrate the problem.